### PR TITLE
Github PR bug

### DIFF
--- a/test-a.txt
+++ b/test-a.txt
@@ -22,7 +22,7 @@ a 21
 a 22
 a 23
 a 24
-a 25
+a 25 changed
 a 26
 a 27
 a 28

--- a/test-b.txt
+++ b/test-b.txt
@@ -47,7 +47,7 @@ b 46
 b 47
 b 48
 b 49
-b 50
+b 50 changed
 b 51
 b 52
 b 53

--- a/test-c.txt
+++ b/test-c.txt
@@ -72,7 +72,7 @@ c 71
 c 72
 c 73
 c 74
-c 75
+c 75 changed
 c 76
 c 77
 c 78


### PR DESCRIPTION
This PR shows a bug in GitHub.

If you go to the diff view (tab `Files changed`) and click on "Expand" (button on the left side of the blue row), then lines from a wrong file are loaded. More specifically:
- expanding something in `test-a.txt` loads lines from `test-b.txt`
- expanding something in `test-b.txt` loads lines from `test-c.txt`

Expand in the last file (`test-c.txt`) works as expected.

It seems that the commited submodule messes with the expand button.